### PR TITLE
Fix critical bugs found in full project review (security, deployment safety, strategy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest tests/ -q

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ __pycache__/
 *$py.class
 *.so
 
+# Runtime state and databases
+data/performance.db
+data/adaptive_state.json
+data/strategy_versions/
+data/strategy_backups/
+
 fitness_log.txt
 
 generation_*.txt

--- a/adaptive/adaptive_optimizer.py
+++ b/adaptive/adaptive_optimizer.py
@@ -119,7 +119,9 @@ class AdaptiveOptimizer:
         version_control: Optional[StrategyVersionControl] = None,
         performance_db: Optional[PerformanceDB] = None,
         config: Optional[AdaptiveConfig] = None,
-        state_file: str = "data/adaptive_state.json"
+        state_file: str = "data/adaptive_state.json",
+        strategy_deployer: Optional[StrategyDeployer] = None,
+        rollback_manager: Optional[RollbackManager] = None,
     ):
         """
         Initialize adaptive optimizer.
@@ -131,6 +133,9 @@ class AdaptiveOptimizer:
             performance_db: Performance database
             config: Adaptive optimization configuration
             state_file: Path to state persistence file
+            strategy_deployer: Deployer configured with the real target strategy
+                dir; without it the default container path is assumed
+            rollback_manager: External rollback manager to reuse
         """
         self.strategy_name = strategy_name
         self.config = config or AdaptiveConfig()
@@ -157,8 +162,8 @@ class AdaptiveOptimizer:
             win_rate_threshold=self.config.win_rate_decline_trigger,
         )
 
-        self.deployer = StrategyDeployer(self.version_control, self.client)
-        self.rollback_manager = RollbackManager(
+        self.deployer = strategy_deployer or StrategyDeployer(self.version_control, self.client)
+        self.rollback_manager = rollback_manager or RollbackManager(
             self.version_control,
             self.monitor,
             self.detector,
@@ -167,6 +172,8 @@ class AdaptiveOptimizer:
                 max_drawdown=self.config.drawdown_trigger
             )
         )
+        # 让自动回滚真正恢复策略文件，而不是只改版本库状态
+        self.rollback_manager.set_deploy_callback(self.deployer.rollback)
 
         # State
         self._state = AdaptiveState.IDLE

--- a/agent_api/api_server.py
+++ b/agent_api/api_server.py
@@ -111,6 +111,22 @@ class AgentAPIHandler(BaseHTTPRequestHandler):
             ))
             return
 
+        if not self.auth_manager.check_permission(api_key, 'read'):
+            self._send_response(APIResponse(
+                success=False,
+                error="Read permission required",
+                status_code=403
+            ))
+            return
+
+        if not self.auth_manager.check_rate_limit(api_key.key_id):
+            self._send_response(APIResponse(
+                success=False,
+                error="Rate limit exceeded",
+                status_code=429
+            ))
+            return
+
         parsed = urlparse(self.path)
         path = parsed.path.rstrip('/')
 
@@ -171,6 +187,14 @@ class AgentAPIHandler(BaseHTTPRequestHandler):
                 success=False,
                 error="Write permission required",
                 status_code=403
+            ))
+            return
+
+        if not self.auth_manager.check_rate_limit(api_key.key_id):
+            self._send_response(APIResponse(
+                success=False,
+                error="Rate limit exceeded",
+                status_code=429
             ))
             return
 
@@ -429,11 +453,27 @@ class AgentAPIHandler(BaseHTTPRequestHandler):
             ))
             return
 
-        # This would trigger the rollback manager
-        self._send_response(APIResponse(
-            success=True,
-            data={'message': f'Rollback requested for {strategy_name}'}
-        ))
+        if not self.adaptive_optimizer:
+            self._send_response(APIResponse(
+                success=False,
+                error="Rollback not available: no adaptive optimizer attached to API server",
+                status_code=501
+            ))
+            return
+
+        success = self.adaptive_optimizer.deployer.rollback(strategy_name, to_version)
+        if success:
+            self._send_response(APIResponse(
+                success=True,
+                data={'message': f'Rolled back {strategy_name}'
+                                 + (f' to {to_version}' if to_version else ' to previous version')}
+            ))
+        else:
+            self._send_response(APIResponse(
+                success=False,
+                error=f"Rollback failed for {strategy_name}, check server logs",
+                status_code=500
+            ))
 
 
 class AgentAPI:

--- a/docker-compose.adaptive.yml
+++ b/docker-compose.adaptive.yml
@@ -17,7 +17,7 @@ services:
   genetrader-daemon:
     build:
       context: .
-      dockerfile: Dockerfile.adaptive
+      dockerfile: Dockerfile
     container_name: genetrader-daemon
     restart: unless-stopped
     environment:
@@ -50,7 +50,7 @@ services:
   agent-api:
     build:
       context: .
-      dockerfile: Dockerfile.adaptive
+      dockerfile: Dockerfile
     container_name: genetrader-api
     restart: unless-stopped
     ports:
@@ -58,7 +58,7 @@ services:
     environment:
       - GENETRADER_CONFIG=/app/ga.json
       - PYTHONPATH=/app
-      - AGENT_API_KEY=${AGENT_API_KEY:-default-key}
+      - AGENT_API_KEY=${AGENT_API_KEY:?请设置 AGENT_API_KEY 环境变量}
     volumes:
       - ./ga.json:/app/ga.json:ro
       - ./data:/app/data

--- a/genetic_algorithm/individual.py
+++ b/genetic_algorithm/individual.py
@@ -88,6 +88,3 @@ class Individual:
                 available_pairs.append(old_pair)
 
                 self.trading_pairs[i] = new_pair
-
-        # Preserve order by only updating changed pairs
-        self.trading_pairs = list(current_pairs)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import sys
 from typing import List, Optional, Tuple
 from datetime import datetime, date
 
@@ -126,6 +127,7 @@ def main():
 
     except Exception as e:
         logger.exception(f"An error occurred: {str(e)}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/monitoring/degradation_detector.py
+++ b/monitoring/degradation_detector.py
@@ -393,7 +393,8 @@ class DegradationDetector:
         self._cusum_std = std
 
         # Calculate CUSUM for recent values
-        recent = profits[:self.lookback_periods // 2]
+        # profits are newest-first; CUSUM must accumulate in chronological order
+        recent = list(reversed(profits[:self.lookback_periods // 2]))
         cusum_pos = 0.0
         cusum_neg = 0.0
         slack = 0.5 * std  # Slack parameter

--- a/run_adaptive.py
+++ b/run_adaptive.py
@@ -136,6 +136,8 @@ class AdaptiveRunner:
             version_control=self.version_control,
             performance_db=self.db,
             config=adaptive_config,
+            strategy_deployer=self.deployer,
+            rollback_manager=self.rollback_manager,
         )
 
         # Scheduler
@@ -152,7 +154,12 @@ class AdaptiveRunner:
 
     def start_api(self, host: str = '0.0.0.0', port: int = 8090):
         """Start the Agent API server."""
-        api_key = getattr(self.settings, 'agent_api_key', '') or os.environ.get('AGENT_API_KEY', 'default-key')
+        api_key = getattr(self.settings, 'agent_api_key', '') or os.environ.get('AGENT_API_KEY', '')
+        if not api_key:
+            logger.warning(
+                "未配置 agent_api_key（ga.json）或 AGENT_API_KEY 环境变量，"
+                "API 将拒绝所有请求。请配置密钥后重启。"
+            )
 
         self.api = AgentAPI(
             host=host,

--- a/scripts/genetrader_daemon.py
+++ b/scripts/genetrader_daemon.py
@@ -112,6 +112,7 @@ class GeneTraderDaemon:
         self._last_optimization_time: Optional[datetime] = None
         self._consecutive_failures = 0
         self._alerts_sent_today = 0
+        self._alerts_date = datetime.now().date()
 
     def _init_components(self):
         """Initialize all system components."""
@@ -214,6 +215,7 @@ class GeneTraderDaemon:
                 api_key=api_key,
                 performance_db=self.db,
                 version_control=self.version_control,
+                adaptive_optimizer=self.adaptive,
                 scheduler=self.scheduler,
             )
             logger.info(f"✅ Agent API will start on port {api_port}")
@@ -355,7 +357,11 @@ class GeneTraderDaemon:
         for alert in result.alerts:
             logger.warning(f"  Alert: {alert.alert_type.value} - {alert.message}")
 
-        # Send notification (limit to once per hour)
+        # Send notification (limit to 24 per day)
+        today = datetime.now().date()
+        if today != self._alerts_date:
+            self._alerts_date = today
+            self._alerts_sent_today = 0
         if self._alerts_sent_today < 24:
             send_notification(
                 self.settings,

--- a/scripts/genetrader_daemon.py
+++ b/scripts/genetrader_daemon.py
@@ -198,7 +198,9 @@ class GeneTraderDaemon:
                 check_interval_minutes=self.check_interval // 60,
                 min_hours_between_optimizations=self.optimize_interval // 3600,
                 require_approval=getattr(self.settings, 'agent_approval_required_for_deployment', False),
-            )
+            ),
+            strategy_deployer=self.deployer,
+            rollback_manager=self.rollback_manager,
         )
         logger.info("✅ Adaptive optimizer initialized")
 

--- a/scripts/get_pairs.py
+++ b/scripts/get_pairs.py
@@ -181,10 +181,13 @@ def update_config_json(pairs: List[str], output_config: str) -> bool:
         config['exchange']['pair_whitelist'] = pairs
 
         # Save to specified filename in user_data directory
+        # (write to temp file then rename, so a crash never leaves a corrupt config)
         output_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'user_data', output_config)
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        with open(output_path, 'w', encoding='utf-8') as f:
+        tmp_path = output_path + '.tmp'
+        with open(tmp_path, 'w', encoding='utf-8') as f:
             json.dump(config, f, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, output_path)
 
         logger.info(f"Successfully saved trading pairs to: {output_path}")
         return True

--- a/scripts/workflow.py
+++ b/scripts/workflow.py
@@ -9,6 +9,7 @@ import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
+from urllib.parse import quote
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -244,16 +245,23 @@ class TradeWorkflow:
             # 通过 SSH 执行重启命令
             if not is_restful:
                 port = str(self.remote_server['port'])
-                subprocess.run([
+                result = subprocess.run([
                     'ssh', "-i", self.remote_server['key_path'],
                     "-p", port,
                     self.remote_server['username'] + '@' + self.remote_server['hostname'],
                     'systemctl restart freqtrade'
                 ])
+                if result.returncode != 0:
+                    logger.error(f"SSH 重启 freqtrade 失败，返回码: {result.returncode}")
+                    return False
                 return True
             else:
-                # restart freqtrade by restful api  
-                return self.restart_freqtrade(self.remote_server['api_url'], self.remote_server['username'], self.remote_server['password'])
+                # restart freqtrade by restful api
+                return self.restart_freqtrade(
+                    self.remote_server['api_url'],
+                    self.remote_server['freqtrade_username'],
+                    self.remote_server['freqtrade_password']
+                )
         except Exception as e:
             logger.error(f"重启交易程序失败: {str(e)}")
             return False
@@ -278,7 +286,7 @@ class TradeWorkflow:
         else:
             strategy_name = settings.base_strategy_file.split("/")[-1].split(".")[0]
             message = f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} {strategy_name} {message}"
-            message = message.replace(" ", "%20")
+            message = quote(message, safe='')
             url = f"{self.bark_endpoint}/{self.bark_key}/{message}"
             try:
                 response = requests.get(url)
@@ -364,8 +372,11 @@ class TradeWorkflow:
             
         try:
             # 使用 -i 参数指定 SSH 私钥
-            subprocess.run(['scp', '-i', self.remote_server['key_path'], f'{self.remote_server["username"]}@{self.remote_server["hostname"]}:/root/trade/user_data/config.json', 'user_data/'])
-            subprocess.run(['scp', '-i', self.remote_server['key_path'], f'{self.remote_server["username"]}@{self.remote_server["hostname"]}:/root/trade/user_data/strategies/GeneStrategy.py', 'user_data/strategies/'])
+            result1 = subprocess.run(['scp', '-i', self.remote_server['key_path'], f'{self.remote_server["username"]}@{self.remote_server["hostname"]}:/root/trade/user_data/config.json', 'user_data/'])
+            result2 = subprocess.run(['scp', '-i', self.remote_server['key_path'], f'{self.remote_server["username"]}@{self.remote_server["hostname"]}:/root/trade/user_data/strategies/GeneStrategy.py', 'user_data/strategies/'])
+            if result1.returncode != 0 or result2.returncode != 0:
+                logger.error(f"从服务器下载文件失败 (config: {result1.returncode}, strategy: {result2.returncode})")
+                return False
             return True
         except Exception as e:
             logger.error(f"下载策略到本地失败: {str(e)}")
@@ -383,11 +394,15 @@ class TradeWorkflow:
         pattern = r'class GeneTrader_gen\d+_\d+_\d+\(IStrategy\):'
         # new_content = re.sub(pattern, f'class {new_class_name}(IStrategy)', content)
         new_content = re.sub(pattern, f'class {new_class_name}(IStrategy):\n    def version(self) -> str:\n        return {timestring}\n', content)
+        if new_content == content:
+            logger.error(f"未在 {file_path} 中找到匹配的策略类定义，重命名失败")
+            return False
         # 写回文件
         with open(src_path, 'w') as file:
             file.write(new_content)
-        
+
         logger.info(f"Successfully renamed strategy class to {new_class_name}")
+        return True
 
     def parse_backtest_results(self, result):
         try:
@@ -476,7 +491,7 @@ class TradeWorkflow:
                 self.send_notification("当前没有最佳策略")
                 return False
             
-            splits = current_best.strip(".txt").split("_")
+            splits = current_best.removesuffix(".txt").split("_")
             generation = splits[-3]
             timestamp = splits[-2]
             number = splits[-1].rstrip(',')  # 移除可能的逗号
@@ -505,7 +520,9 @@ class TradeWorkflow:
 
             # 6. strategy 统一处理
             logger.info("rename strategy: {} to GeneStrategy".format(strategy_file))
-            self.rename_strategy_class(strategy_file, "strategies/GeneStrategy.py")
+            if not self.rename_strategy_class(strategy_file, "strategies/GeneStrategy.py"):
+                self.send_notification("策略类重命名失败")
+                return False
 
             # 7. 复制 config_file 到 strategies 目录， 文件名改为config.json
             logger.info("copy config file")

--- a/strategies/GeneStrategy.py
+++ b/strategies/GeneStrategy.py
@@ -300,9 +300,9 @@ class GeneStrategy(IStrategy):
             #elif (current_time - timedelta(minutes=400) > trade.open_date_utc) & (current_profit > 0) & (current_profit < self.sell_custom_roi_profit_5.value) & (last_candle['sma_200_dec_1h']):
             #    return 'roi_target_5'
 
-            if (current_profit > self.sell_trail_profit_min_1.value) & (current_profit < self.sell_trail_profit_max_1.value) & (((trade.max_rate - trade.open_rate) / 100) > (current_profit + self.sell_trail_down_1.value)):
+            if (current_profit > self.sell_trail_profit_min_1.value) & (current_profit < self.sell_trail_profit_max_1.value) & (((trade.max_rate - trade.open_rate) / trade.open_rate) > (current_profit + self.sell_trail_down_1.value)):
                 return 'trail_target_1'
-            elif (current_profit > self.sell_trail_profit_min_2.value) & (current_profit < self.sell_trail_profit_max_2.value) & (((trade.max_rate - trade.open_rate) / 100) > (current_profit + self.sell_trail_down_2.value)):
+            elif (current_profit > self.sell_trail_profit_min_2.value) & (current_profit < self.sell_trail_profit_max_2.value) & (((trade.max_rate - trade.open_rate) / trade.open_rate) > (current_profit + self.sell_trail_down_2.value)):
                 return 'trail_target_2'
             elif (current_profit > 3) & (last_candle['rsi'] > 85):
                  return 'RSI-85 target'
@@ -537,8 +537,8 @@ class GeneStrategy(IStrategy):
 
         informative['ha_close'] = inf_heikinashi['close']
         informative['rocr'] = ta.ROCR(informative['ha_close'], timeperiod=168)
-        informative['rsi_14'] = ta.RSI(dataframe, timeperiod=14)
-        informative['cmf'] = chaikin_money_flow(dataframe, 20)
+        informative['rsi_14'] = ta.RSI(informative, timeperiod=14)
+        informative['cmf'] = chaikin_money_flow(informative, 20)
         sup_series = informative['low'].rolling(window = 5, center=True).apply(lambda row: self.is_support(row), raw=True).shift(2)
         informative['sup_level'] = Series(np.where(sup_series, np.where(informative['close'] < informative['open'], informative['close'], informative['open']), float('NaN'))).ffill()
         informative['roc'] = ta.ROC(informative, timeperiod=9)

--- a/strategy/robustness.py
+++ b/strategy/robustness.py
@@ -134,8 +134,8 @@ class ParameterSensitivityAnalyzer:
                 if perturbed_fitness is not None and original_fitness > 0:
                     change = abs(perturbed_fitness - original_fitness) / original_fitness
                     fitness_changes.append(change)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Sensitivity eval failed for param index {index}: {e}")
 
         if not fitness_changes:
             return 0.5  # Unknown sensitivity
@@ -164,8 +164,8 @@ class ParameterSensitivityAnalyzer:
             if perturbed_fitness is not None and original_fitness > 0:
                 change = abs(perturbed_fitness - original_fitness) / original_fitness
                 return min(1.0, change)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Sensitivity eval failed for boolean param index {index}: {e}")
 
         return 0.5
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration.
+
+Some modules load the global Settings singleton at import time, which
+requires a ga.json config file. Fall back to ga.json.example so the test
+suite can be collected and run on a fresh checkout (and in CI) without a
+personal config.
+"""
+import os
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+if 'GENETRADER_CONFIG' not in os.environ and not (_PROJECT_ROOT / 'ga.json').exists():
+    os.environ['GENETRADER_CONFIG'] = str(_PROJECT_ROOT / 'ga.json.example')

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -200,7 +200,8 @@ class TestFitnessFunction(unittest.TestCase):
             'sortino_ratio': 2.5,
             'profit_factor': 2.0,
             'daily_avg_trades': 3.5,
-            'avg_trade_duration': 720  # 12 hours
+            'avg_trade_duration': 720,  # 12 hours
+            'total_trades': 200
         }
         self.bad_results = {
             'total_profit_percent': -0.20,  # -20% loss
@@ -210,7 +211,8 @@ class TestFitnessFunction(unittest.TestCase):
             'sortino_ratio': 0.5,
             'profit_factor': 0.5,
             'daily_avg_trades': 0.5,
-            'avg_trade_duration': 10000  # Too long
+            'avg_trade_duration': 10000,  # Too long
+            'total_trades': 50
         }
 
     @patch('strategy.evaluation.open', create=True)

--- a/user_data/example.json
+++ b/user_data/example.json
@@ -196,10 +196,10 @@
         "listen_ip_address": "0.0.0.0",
         "listen_port": 8080,
         "verbosity": "info",
-        "jwt_secret_key": "somethingrandom",
+        "jwt_secret_key": "CHANGE_ME_random_string",
         "CORS_origins": [],
-        "username": "jwz",
-        "password": "zhangjiawei"
+        "username": "your_username",
+        "password": "your_password"
     },
     "bot_name": "freqtrade",
     "initial_state": "running",


### PR DESCRIPTION
## Summary

Two-round deep review of the whole project, with every finding verified against the code before fixing. 210 tests pass (the suite previously could not even be collected without a personal `ga.json`).

### Security
- Remove hardcoded `default-key` API key fallback (`run_adaptive.py`, docker-compose); the API now fails closed when no key is configured
- Replace real-looking credentials in `user_data/example.json` with placeholders — **note: the old values remain in git history, please rotate the actual freqtrade password**
- Enforce `read` permission on GET endpoints (a write-only key could previously read everything)
- Wire up the existing-but-never-called rate limiter on GET/POST

### Deployment safety
- Auto-rollback previously only flipped DB status and never restored the strategy file; `RollbackManager` deploy callback is now wired to `StrategyDeployer.rollback`
- `AdaptiveOptimizer` silently used a hardcoded `/freqtrade/user_data/strategies` deploy path; it now accepts the correctly-configured deployer from `run_adaptive.py` / `genetrader_daemon.py`
- `/api/v1/rollback` was a placeholder returning fake success while doing nothing; it now executes a real rollback (501 if no optimizer attached)

### Strategy correctness (GeneStrategy.py)
- 1h informative `rsi_14`/`cmf` were computed from the 5m dataframe (copy-paste bug), corrupting the `*_1h` columns used in DCA gating
- `custom_sell` trailing exit compared an absolute price delta divided by 100 against a profit ratio (dimensionally wrong); now divides by `open_rate`
- ⚠️ These change backtest/live behavior. The same bugs almost certainly exist in the base template (`base_strategy_file`, e.g. `candidates/E0V1E_Bull.py`) on the runtime machine — fix it there too or the next optimization run will regenerate them.

### Monitoring
- CUSUM accumulated snapshots newest-first, inverting the algorithm's time semantics; now chronological

### Workflow & scripts
- `workflow.py`: `KeyError: 'password'` made the RESTful freqtrade restart path always fail; ssh/scp return codes now checked; Bark notifications URL-encoded; silent no-op strategy rename now errors; `strip(".txt")` misuse fixed
- `main.py` exits non-zero on failure so `workflow.py` can detect it
- Daemon degradation-alert counter now resets daily (previously went permanently silent after 24 alerts)
- `get_pairs.py` writes the live config atomically
- `individual.py` no longer destroys trading-pair order after mutation

### Infrastructure
- Fix docker-compose reference to nonexistent `Dockerfile.adaptive`
- `tests/conftest.py` falls back to `ga.json.example` (fixes 3 collection errors on fresh checkouts)
- Add GitHub Actions CI (pytest on Python 3.11/3.12)

## Known issues intentionally left for follow-up (design decisions needed)
- Approval chain is dead code end-to-end (API approve/reject only mutates memory; `set_approval_callback` never called in production)
- `shadow_trader.py` and `GradualRolloutManager` are unwired mocks despite config fields promising them
- `performance_monitor.py` computes profit/drawdown by arithmetic sum instead of compounded equity
- WebSocket manager has no transport attached
- API uses synchronous `HTTPServer` with unlocked shared dicts

## Test plan
- `python3 -m pytest tests/ -q` → 210 passed
- All touched files compile; rollback callback wiring verified by direct construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)