### PR TITLE
Report the GA's own selection bar alongside the winner

### DIFF
--- a/optimization/genetic_optimizer.py
+++ b/optimization/genetic_optimizer.py
@@ -24,6 +24,7 @@ from genetic_algorithm.operators import (
 )
 from strategy.backtest import run_backtest
 from strategy.walk_forward import WalkForwardValidator, create_validator_from_settings
+from strategy.selection_bar import from_fitnesses as selection_bar
 from utils.logging_config import logger
 
 
@@ -294,6 +295,15 @@ class GeneticOptimizer(BaseOptimizer):
                     self.best_individual = best_individual
 
                 logger.info(f"Best individual in generation {gen+1}: Fitness: {best_individual.fitness:.4f}")
+
+                # How good would the best of this many candidates have looked
+                # anyway? A winner below its own bar has not beaten noise.
+                bar = selection_bar(
+                    [ind.fitness for ind in population.individuals],
+                    n_trials=(gen + 1) * self.settings.population_size,
+                )
+                if bar:
+                    logger.info(f"Generation {gen+1} {bar.summary()}")
 
                 if checkpoint_name and checkpoint_frequency and (gen + 1) % checkpoint_frequency == 0:
                     self._save_checkpoint(checkpoint_name, gen + 1, population, best_individuals)

--- a/scripts/selection_bar.py
+++ b/scripts/selection_bar.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Report the GA's own selection bar from fitness logs.
+
+Answers "how good would the best of N candidates have looked anyway?" using the
+dispersion of fitness this search actually produced, so the bar is measured
+rather than assumed.
+
+Usage:
+    python scripts/selection_bar.py
+    python scripts/selection_bar.py --log daily_results/20241223/gen10/fitness_info.txt
+    python scripts/selection_bar.py --per-generation --json
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+from typing import Any, Dict, List
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from strategy.selection_bar import compute, is_degenerate, scoreable  # noqa: E402
+
+FIELDS = {
+    'fitness': 'Final Fitness',
+    'sharpe': 'Sharpe Ratio',
+    'profit_factor': 'Profit Factor',
+    'win_rate': 'Win Rate',
+    'max_drawdown': 'Max Drawdown',
+    'generation': 'Generation',
+}
+PATTERNS = {key: re.compile(re.escape(label) + r":\s*(-?[\d.]+)")
+            for key, label in FIELDS.items()}
+DEFAULT_GLOBS = ('daily_results/**/fitness_info.txt', 'logs/fitness_log.txt')
+
+
+def parse_log(path: str) -> List[Dict[str, float]]:
+    records = []
+    with open(path, encoding='utf-8', errors='replace') as f:
+        for line in f:
+            if FIELDS['fitness'] not in line:
+                continue
+            record = {}
+            for key, pattern in PATTERNS.items():
+                m = pattern.search(line)
+                if m:
+                    record[key] = float(m.group(1))
+            if 'fitness' in record:
+                records.append(record)
+    return records
+
+
+def collect(paths: List[str]) -> List[Dict[str, float]]:
+    records = []
+    for path in paths:
+        records.extend(parse_log(path))
+    return records
+
+
+def resolve_paths(explicit: List[str]) -> List[str]:
+    if explicit:
+        return explicit
+    for pattern in DEFAULT_GLOBS:
+        found = sorted(glob.glob(pattern, recursive=True))
+        if found:
+            return found
+    return []
+
+
+def report(result, label: str = '') -> None:
+    prefix = f"{label}  " if label else ''
+    print(f"{prefix}candidates evaluated : {result.n_evaluated}")
+    print(f"{prefix}scored (after filter): {result.n_scored}  "
+          f"(dropped {result.n_dropped})")
+    print(f"{prefix}fitness mean         : {result.mean:.4f}")
+    print(f"{prefix}fitness spread (sd)  : {result.dispersion:.4f}")
+    print(f"{prefix}winner               : {result.winner:.4f}")
+    print(f"{prefix}chance bar           : {result.bar:.4f}")
+    print(f"{prefix}edge                 : {result.edge:+.4f}"
+          f"   -> winner is {'above' if result.clears_bar else 'BELOW'} the bar")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--log', action='append', default=[],
+                        help='Fitness log to read (repeatable). Default: daily_results/**/fitness_info.txt')
+    parser.add_argument('--n-trials', type=int, default=None,
+                        help='Override trial count, e.g. the full search size when the log is a sample')
+    parser.add_argument('--per-generation', action='store_true',
+                        help='Also report a bar per generation')
+    parser.add_argument('--keep-degenerate', action='store_true',
+                        help='Do not filter zero-drawdown / zero-profit-factor entries (for comparison)')
+    parser.add_argument('--json', action='store_true', help='Emit JSON')
+    args = parser.parse_args()
+
+    paths = resolve_paths(args.log)
+    if not paths:
+        print('No fitness logs found. Pass --log <path>.', file=sys.stderr)
+        return 1
+
+    records = collect(paths)
+    if not records:
+        print(f'No fitness entries parsed from: {", ".join(paths)}', file=sys.stderr)
+        return 1
+
+    result = compute(records, n_trials=args.n_trials,
+                     drop_degenerate=not args.keep_degenerate)
+    if result is None:
+        print('Fewer than two scoreable candidates; nothing to compare.', file=sys.stderr)
+        return 1
+
+    payload: Dict[str, Any] = {'files': paths, 'overall': result.to_dict()}
+
+    degenerate = [r for r in records if is_degenerate(r)]
+    disqualified = len(records) - len(scoreable(records)) - len(degenerate)
+    payload['dropped'] = {'degenerate': len(degenerate), 'disqualified': disqualified}
+
+    if args.per_generation:
+        per_gen = {}
+        for record in records:
+            per_gen.setdefault(int(record.get('generation', 0)), []).append(record)
+        payload['per_generation'] = {}
+        for gen in sorted(per_gen):
+            gen_result = compute(per_gen[gen], drop_degenerate=not args.keep_degenerate)
+            if gen_result:
+                payload['per_generation'][gen] = gen_result.to_dict()
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    print(f"files: {', '.join(paths)}\n")
+    report(result)
+
+    if degenerate:
+        print(f"\ndropped {len(degenerate)} degenerate entries "
+              f"(max drawdown 0 AND profit factor 0 AND win rate 1.0):")
+        print("  freqtrade reports these when no losing trade was ever closed, so the")
+        print("  summary hides the risk in still-open positions. They score maximum")
+        print("  drawdown and win-rate points and outrank real strategies.")
+        best_degenerate = max(degenerate, key=lambda r: r['fitness'])
+        print(f"  best of them scored {best_degenerate['fitness']:.4f} "
+              f"vs {result.winner:.4f} for the best real candidate")
+    if disqualified:
+        print(f"\ndropped {disqualified} disqualified entries (fitness <= -1, a rejection code)")
+
+    if args.per_generation and payload.get('per_generation'):
+        print("\nper generation:")
+        print(f"  {'gen':>4} {'n':>5} {'spread':>9} {'winner':>9} {'bar':>9} {'edge':>9}")
+        for gen, data in payload['per_generation'].items():
+            print(f"  {gen:4d} {data['n_scored']:5d} {data['dispersion']:9.4f} "
+                  f"{data['winner']:9.4f} {data['bar']:9.4f} {data['edge']:+9.4f}")
+
+    print("\nHow to read this")
+    print("  The bar is what the best of n candidates would be expected to reach with")
+    print("  no skill, given the spread this search produced. Clearing it is necessary,")
+    print("  not sufficient: evaluations within a GA are not independent trials, and")
+    print("  fitness is not normally distributed. Treat it as a screen. The real test")
+    print("  of curve-fitting is out-of-sample -- set enable_walk_forward and compare")
+    print("  train against test folds.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/strategy/selection_bar.py
+++ b/strategy/selection_bar.py
@@ -1,0 +1,185 @@
+"""How good would the best of N random strategies have looked anyway?
+
+A GA that evaluates 900 candidates and reports the best one has run 900
+experiments and published the winner. Some of that winner's score is skill and
+some is the luck of being the luckiest of 900 draws. This module estimates the
+luck component: given the spread of fitness actually observed in the
+population, what score would the best of N zero-skill candidates be expected to
+reach? That value is the search's own selection bar, and a winner that does not
+clear it has not demonstrated anything the search couldn't have produced from
+noise.
+
+The estimator is the Bailey / Lopez de Prado false-strategy benchmark used for
+the Deflated Sharpe Ratio, applied to the quantity this project actually
+selects on -- Final Fitness -- rather than to Sharpe. Sharpe is one weighted
+input to fitness (see strategy/evaluation.py); deflating it would measure
+selection pressure that was never applied.
+
+Read the output as a screening diagnostic, not a verdict. Two assumptions are
+knowingly violated:
+
+  * Independence. Generation N+1 descends from generation N by selection,
+    crossover, and mutation, so evaluations are not independent trials. Using
+    the full evaluation count overstates the number of independent draws, which
+    raises the bar -- the test is therefore conservative on that axis.
+  * Normality. Fitness is a bounded weighted sum, not a normal variate.
+
+The real answer to "is this curve-fitted" is out-of-sample performance. Set
+enable_walk_forward and compare train against test folds. This number is a
+cheap in-sample screen that runs on data you already have.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional, Sequence
+
+EULER_MASCHERONI = 0.5772156649015329
+
+# fitness_function returns -1.0 .. -4.0 as disqualification codes and
+# run_backtest returns -inf when a backtest produced nothing. Neither is a
+# sample from the distribution of strategy performance.
+DISQUALIFIED_ABOVE = -0.999
+
+
+def _probit(p: float) -> float:
+    """Inverse standard normal CDF (Acklam's rational approximation)."""
+    if not 0.0 < p < 1.0:
+        raise ValueError("probit needs 0 < p < 1")
+    a = (-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02,
+         1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00)
+    b = (-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02,
+         6.680131188771972e+01, -1.328068155288572e+01)
+    c = (-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00,
+         -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00)
+    d = (7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00,
+         3.754408661907416e+00)
+    plow, phigh = 0.02425, 1 - 0.02425
+    if p < plow:
+        q = math.sqrt(-2 * math.log(p))
+        return ((((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5])
+                / ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1))
+    if p > phigh:
+        q = math.sqrt(-2 * math.log(1 - p))
+        return -((((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5])
+                 / ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1))
+    q = p - 0.5
+    r = q * q
+    return ((((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r+a[5])*q
+            / (((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r+1))
+
+
+def expected_max(n_trials: int, dispersion: float) -> float:
+    """Expected maximum of ``n_trials`` iid draws from N(0, dispersion^2).
+
+    This is the increment above the mean that the luckiest of n zero-skill
+    candidates is expected to reach.
+    """
+    if dispersion <= 0 or n_trials < 2:
+        return 0.0
+    z1 = _probit(1 - 1.0 / n_trials)
+    z2 = _probit(1 - 1.0 / (n_trials * math.e))
+    return dispersion * ((1 - EULER_MASCHERONI) * z1 + EULER_MASCHERONI * z2)
+
+
+@dataclass
+class SelectionBar:
+    """Winner versus the score the search could have reached by luck."""
+    n_evaluated: int
+    n_scored: int          # after dropping disqualified / degenerate entries
+    n_dropped: int
+    mean: float
+    dispersion: float
+    winner: float
+    bar: float             # mean + expected_max(n_scored, dispersion)
+    edge: float            # winner - bar
+    clears_bar: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def summary(self) -> str:
+        verdict = "above" if self.clears_bar else "BELOW"
+        return (f"selection bar: winner={self.winner:.4f} {verdict} "
+                f"chance-bar={self.bar:.4f} (edge {self.edge:+.4f}) from "
+                f"n={self.n_scored} scored candidates, spread={self.dispersion:.4f}")
+
+
+def is_degenerate(record: Dict[str, float]) -> bool:
+    """True for backtests whose metrics cannot be what they claim.
+
+    Freqtrade reports profit factor 0 and max drawdown 0 when it has no losing
+    trade to divide by. Combined with a perfect win rate that means no loss was
+    ever realised -- typically a strategy that simply never closes a losing
+    position, leaving the risk in open trades where the summary cannot see it.
+    Such a candidate scores maximum drawdown-penalty and win-rate points, so it
+    outranks real strategies. Current fitness_function rejects it on the profit
+    factor check, but historical logs predate that guard.
+    """
+    return (record.get('max_drawdown', 1.0) == 0.0
+            and record.get('profit_factor', 1.0) == 0.0
+            and record.get('win_rate', 0.0) >= 0.999)
+
+
+def scoreable(records: Sequence[Dict[str, float]],
+              drop_degenerate: bool = True) -> List[Dict[str, float]]:
+    """Keep only entries that represent a real evaluated strategy."""
+    kept = []
+    for r in records:
+        fitness = r.get('fitness')
+        if fitness is None or not math.isfinite(fitness):
+            continue
+        if fitness <= DISQUALIFIED_ABOVE:
+            continue
+        if drop_degenerate and is_degenerate(r):
+            continue
+        kept.append(r)
+    return kept
+
+
+def compute(records: Sequence[Dict[str, float]],
+            n_trials: Optional[int] = None,
+            drop_degenerate: bool = True) -> Optional[SelectionBar]:
+    """Compute the selection bar for a pool of evaluated candidates.
+
+    Args:
+        records: dicts with at least ``fitness``; ``max_drawdown``,
+            ``profit_factor`` and ``win_rate`` enable degenerate filtering.
+        n_trials: override the trial count. Defaults to the number of scoreable
+            candidates. Pass the full search size when the pool is a sample of
+            a larger search, so the bar reflects everything that was tried.
+        drop_degenerate: exclude backtests that reported no losing trade. Set
+            False only to show what including them would do.
+
+    Returns None when fewer than two candidates survive filtering.
+    """
+    kept = scoreable(records, drop_degenerate=drop_degenerate)
+    if len(kept) < 2:
+        return None
+
+    values = [r['fitness'] for r in kept]
+    mean = statistics.mean(values)
+    dispersion = statistics.pstdev(values)
+    winner = max(values)
+    trials = n_trials if n_trials is not None else len(values)
+    bar = mean + expected_max(trials, dispersion)
+
+    return SelectionBar(
+        n_evaluated=len(records),
+        n_scored=len(kept),
+        n_dropped=len(records) - len(kept),
+        mean=mean,
+        dispersion=dispersion,
+        winner=winner,
+        bar=bar,
+        edge=winner - bar,
+        clears_bar=winner > bar,
+    )
+
+
+def from_fitnesses(fitnesses: Sequence[float],
+                   n_trials: Optional[int] = None) -> Optional[SelectionBar]:
+    """Convenience wrapper when only fitness values are available."""
+    return compute([{'fitness': f} for f in fitnesses], n_trials=n_trials)

--- a/tests/test_selection_bar.py
+++ b/tests/test_selection_bar.py
@@ -1,0 +1,208 @@
+"""Tests for the GA selection bar.
+
+The failure this guards against is a false pass: a bar computed over a pool
+that still contains disqualification codes and impossible backtests reports
+that the winner cleared it, when the winner is one of those artifacts.
+"""
+
+import math
+import os
+import sys
+import unittest
+
+from strategy.selection_bar import (
+    DISQUALIFIED_ABOVE,
+    compute,
+    expected_max,
+    from_fitnesses,
+    is_degenerate,
+    scoreable,
+)
+
+
+def real(fitness, **overrides):
+    """A record that looks like a genuine evaluated strategy."""
+    record = {'fitness': fitness, 'max_drawdown': 0.12,
+              'profit_factor': 1.4, 'win_rate': 0.55}
+    record.update(overrides)
+    return record
+
+
+def degenerate(fitness):
+    """Freqtrade's no-losing-trade signature."""
+    return {'fitness': fitness, 'max_drawdown': 0.0,
+            'profit_factor': 0.0, 'win_rate': 1.0}
+
+
+class TestExpectedMax(unittest.TestCase):
+    def test_more_trials_raises_the_bar(self):
+        bars = [expected_max(n, 1.0) for n in (10, 100, 1000)]
+        self.assertEqual(bars, sorted(bars))
+
+    def test_scales_linearly_with_dispersion(self):
+        self.assertAlmostEqual(expected_max(100, 2.0), 2 * expected_max(100, 1.0), places=9)
+
+    def test_degenerate_inputs_return_zero(self):
+        self.assertEqual(expected_max(1, 1.0), 0.0)
+        self.assertEqual(expected_max(0, 1.0), 0.0)
+        self.assertEqual(expected_max(100, 0.0), 0.0)
+
+    def test_matches_reference_value(self):
+        # Bailey / Lopez de Prado false-strategy benchmark, n=320, sd=1.
+        self.assertAlmostEqual(expected_max(320, 1.0), 2.914, places=2)
+
+
+class TestFiltering(unittest.TestCase):
+    def test_disqualification_codes_are_dropped(self):
+        # fitness_function returns -1.0 .. -4.0 as rejection codes.
+        pool = [real(0.3), real(0.2)] + [real(code) for code in (-1.0, -2.0, -3.0, -4.0)]
+        self.assertEqual(len(scoreable(pool)), 2)
+
+    def test_non_finite_fitness_is_dropped(self):
+        pool = [real(0.3), real(float('-inf')), real(float('nan')), real(0.2)]
+        self.assertEqual(len(scoreable(pool)), 2)
+
+    def test_boundary_of_disqualification(self):
+        self.assertEqual(len(scoreable([real(DISQUALIFIED_ABOVE + 0.001), real(0.1)])), 2)
+        self.assertEqual(len(scoreable([real(-1.0), real(0.1)])), 1)
+
+    def test_degenerate_signature(self):
+        self.assertTrue(is_degenerate(degenerate(0.5)))
+        self.assertFalse(is_degenerate(real(0.5)))
+        # All three conditions are required.
+        self.assertFalse(is_degenerate({'fitness': 0.5, 'max_drawdown': 0.0,
+                                        'profit_factor': 2.0, 'win_rate': 1.0}))
+        self.assertFalse(is_degenerate({'fitness': 0.5, 'max_drawdown': 0.1,
+                                        'profit_factor': 0.0, 'win_rate': 1.0}))
+
+    def test_records_without_metrics_are_kept(self):
+        # Fitness-only pools cannot be checked for degeneracy; keep them.
+        self.assertEqual(len(scoreable([{'fitness': 0.3}, {'fitness': 0.4}])), 2)
+
+    def test_degenerate_filtering_can_be_disabled(self):
+        pool = [real(0.3), degenerate(0.9), real(0.2)]
+        self.assertEqual(len(scoreable(pool)), 2)
+        self.assertEqual(len(scoreable(pool, drop_degenerate=False)), 3)
+
+
+class TestCompute(unittest.TestCase):
+    def test_returns_none_when_too_few_survive(self):
+        self.assertIsNone(compute([]))
+        self.assertIsNone(compute([real(0.5)]))
+        self.assertIsNone(compute([real(-1.0), real(-2.0), real(0.3)]))
+
+    def test_counts_are_reported(self):
+        pool = [real(0.3), real(0.2), real(-1.0), degenerate(0.9)]
+        result = compute(pool)
+        self.assertEqual(result.n_evaluated, 4)
+        self.assertEqual(result.n_scored, 2)
+        self.assertEqual(result.n_dropped, 2)
+
+    def test_winner_excludes_filtered_entries(self):
+        result = compute([real(0.3), real(0.2), degenerate(0.99)])
+        self.assertAlmostEqual(result.winner, 0.3)
+
+    def test_bar_is_mean_plus_expected_max(self):
+        values = [0.1, 0.2, 0.3, 0.4, 0.5]
+        result = from_fitnesses(values)
+        import statistics
+        expected = statistics.mean(values) + expected_max(5, statistics.pstdev(values))
+        self.assertAlmostEqual(result.bar, expected, places=9)
+        self.assertAlmostEqual(result.edge, result.winner - result.bar, places=9)
+
+    def test_n_trials_override_raises_the_bar(self):
+        values = [0.1, 0.2, 0.3, 0.4, 0.5]
+        small = from_fitnesses(values)
+        large = from_fitnesses(values, n_trials=10000)
+        self.assertGreater(large.bar, small.bar)
+        self.assertLess(large.edge, small.edge)
+
+    def test_an_outlier_winner_clears_the_bar(self):
+        result = from_fitnesses([0.10, 0.11, 0.12, 0.13, 0.14, 5.0])
+        self.assertTrue(result.clears_bar)
+        self.assertGreater(result.edge, 0)
+
+    def test_an_evenly_spread_population_has_no_standout(self):
+        # The top of a smooth ramp is roughly what chance produces at this n.
+        result = from_fitnesses([0.10 + 0.01 * i for i in range(30)])
+        self.assertFalse(result.clears_bar)
+
+    def test_an_identical_population_never_clears(self):
+        result = from_fitnesses([0.2] * 11)
+        self.assertEqual(result.dispersion, 0.0)
+        self.assertFalse(result.clears_bar)
+
+
+class TestDegeneratesCauseFalsePass(unittest.TestCase):
+    """The regression this module exists for.
+
+    Impossible backtests raise both the winner and the spread. Leaving them in
+    can turn a winner that sits below its own selection bar into one that
+    appears to clear it -- exactly the reassurance an overfitting check must
+    never manufacture.
+    """
+
+    def setUp(self):
+        # Artifacts interleave with the real population rather than sitting in
+        # a block above it, which is how they appear in real logs: they raise
+        # the winner more than they raise the bar.
+        self.pool = ([real(0.02 + 0.38 * i / 29) for i in range(30)]
+                     + [degenerate(0.07 + 0.53 * i / 7) for i in range(8)])
+
+    def test_verdict_flips_when_artifacts_are_included(self):
+        honest = compute(self.pool)
+        inflated = compute(self.pool, drop_degenerate=False)
+
+        self.assertFalse(honest.clears_bar)
+        self.assertTrue(inflated.clears_bar)
+        self.assertGreater(inflated.winner, honest.winner)
+        self.assertGreater(inflated.dispersion, honest.dispersion)
+
+    def test_honest_winner_is_a_real_candidate(self):
+        honest = compute(self.pool)
+        best_real = max(r['fitness'] for r in self.pool if not is_degenerate(r))
+        self.assertAlmostEqual(honest.winner, best_real)
+
+    def test_summary_names_the_direction(self):
+        self.assertIn('BELOW', compute(self.pool).summary())
+        self.assertIn('above', compute(self.pool, drop_degenerate=False).summary())
+
+
+class TestAgainstCommittedLog(unittest.TestCase):
+    """Regression against the fitness log committed in daily_results/.
+
+    That run predates the anti-overfitting disqualifications added later, so a
+    quarter of its pool is backtests that reported no losing trade. It is the
+    concrete case this filtering exists for.
+    """
+
+    LOG = os.path.join(os.path.dirname(__file__), '..',
+                       'daily_results', '20241223', 'gen10', 'fitness_info.txt')
+
+    def setUp(self):
+        if not os.path.exists(self.LOG):
+            self.skipTest('committed fitness log not present')
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+        from selection_bar import parse_log
+        self.records = parse_log(self.LOG)
+
+    def test_log_parses(self):
+        self.assertGreater(len(self.records), 100)
+
+    def test_a_quarter_of_the_pool_is_degenerate(self):
+        share = sum(1 for r in self.records if is_degenerate(r)) / len(self.records)
+        self.assertGreater(share, 0.2)
+
+    def test_the_reported_winner_was_an_artifact(self):
+        overall_best = max(self.records, key=lambda r: r['fitness'])
+        self.assertTrue(is_degenerate(overall_best))
+
+    def test_filtering_reverses_the_verdict(self):
+        honest = compute(self.records)
+        inflated = compute(self.records, drop_degenerate=False)
+        self.assertTrue(inflated.clears_bar)
+        self.assertFalse(honest.clears_bar)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Prompted by an unsolicited email suggesting a Deflated Sharpe check on this repo's fitness logs. **The underlying point is right and worth having. The specific computation it proposed reports the opposite of what the data says**, so this implements it correctly, with no third-party dependency.

## The idea

A search that evaluates 900 candidates and reports the best has run 900 experiments and published the winner. Part of that score is skill; part is the luck of being the luckiest of 900 draws. The Bailey / López de Prado false-strategy benchmark estimates the luck component from the dispersion the search actually produced — so the bar is measured, not assumed.

## What was wrong with the proposed version

It deflated **Sharpe**, parsed straight from the logs, and reported `winner=56.06, bar=37.59, edge=+18.47 → clears its own selection bar`.

Three problems, each independently fatal:

1. **The pool is a quarter artifacts.** 77 of 320 entries in the committed log have `Max Drawdown: 0.0000` **and** `Profit Factor: 0.0000` **and** `Win Rate: 1.0000`. Freqtrade prints that when it has no losing trade to divide by — a strategy that never closes a loser, leaving the risk in open positions the summary cannot see. Their mean Sharpe is 30.2, and **the reported `winner=56.06` is one of them**.
2. **The GA does not select on Sharpe.** It selects on `Final Fitness`; Sharpe is one weighted input (`strategy/evaluation.py`). `argmax(Sharpe)` and `argmax(Fitness)` are different individuals in that log. Deflating Sharpe measures selection pressure that was never applied.
3. **Evaluations are not independent trials.** Generation N+1 descends from N by selection, crossover, and mutation. Per-generation dispersion falls from 15.01 to 10.74 across the run — the population converging.

## What this reports instead

Deflates `Final Fitness`, after dropping disqualification codes (`fitness_function` returns −1.0 … −4.0; `run_backtest` returns −inf) and the no-losing-trade signature.

On the same committed log:

| pool | winner | bar | edge | verdict |
|---|---|---|---|---|
| with artifacts | 0.5999 | 0.5310 | **+0.0689** | above |
| filtered | 0.4068 | 0.4217 | **−0.0149** | **below** |

The artifacts raise the winner more than they raise the bar, so leaving them in converts a fail into a pass. **An overfitting check that manufactures a pass is worse than no check** — a test pins this reversal so it cannot regress.

That log is from 2024-12, before the anti-overfitting disqualifications landed in 393a024. Current `fitness_function` scores that same degenerate winner **−3.0** on the profit-factor check, so today's code already rejects them. The filtering exists for historical logs and as a backstop.

## Deliberately reports no verdict

No PASS/SURVIVES line. Both assumptions behind the estimator are violated here — trials are correlated by descent, and fitness is a bounded weighted sum, not normal. The output states both and points at walk-forward (now real, per #20) as the actual out-of-sample test. This is a screen, not a proof.

## Usage

```bash
python scripts/selection_bar.py                     # pooled
python scripts/selection_bar.py --per-generation    # per generation
python scripts/selection_bar.py --keep-degenerate   # show what including artifacts does
```

Each generation now also logs its bar next to its winner during optimization.

## No new dependencies

`strategy/selection_bar.py` is stdlib-only (`math`, `statistics`). The suggested package turned out to be the client SDK for a metered pay-per-call service (prepaid credits + x402 on-chain settlement, hard dependency on `mcp`, installs an MCP server entry point) rather than the standalone MIT helper it was described as. Source review found no backdoor, but there is no reason to put a payments SDK in the path of a trading system for fifteen lines of arithmetic.

## Test plan

- `python3 -m pytest tests/ -q` → **286 passed** (261 before)
- `tests/test_selection_bar.py` adds 25, including a regression that reads the committed log and asserts the reversal
- End-to-end: a mocked GA run logs the bar for each generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)